### PR TITLE
Ability to run arbitrary p4 commands

### DIFF
--- a/p4.js
+++ b/p4.js
@@ -8,7 +8,7 @@ function runCommand(command, args, done) {
         if(err) return done(err);
         if(stdErr) return done(new Error(stdErr));
 
-        done();
+        done(null, stdOut);
     });
 }
 
@@ -31,3 +31,4 @@ function smartEdit(path, done) {
 exports.edit = edit;
 exports.add = add;
 exports.smartEdit = smartEdit;
+exports.run = runCommand;


### PR DESCRIPTION
Expose `.runCommand()` as `.run()` on exports. Also made `.runCommand()` pass the value of `stdOut` to the `done()` callback because that seems pretty useful.
